### PR TITLE
Show items on navbar website

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -18,9 +18,3 @@ reference:
 - title: Other functions
   contents:
   - tiler_options
-
-navbar:
-  type: inverse
-  right:
-    - icon: fa-github fa-lg
-      href: https://github.com/leonawicz/tiler


### PR DESCRIPTION
Currently, there is no link to access reference, news, vignettes.

The gh link will appear by default