### PR TITLE
docs: fix pkgdown navbar config

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -19,8 +19,3 @@ reference:
   contents:
   - tiler_options
 
-navbar:
-  type: inverse
-  right:
-    - icon: fa-github fa-lg
-      href: https://github.com/leonawicz/tiler


### PR DESCRIPTION
and in case you want to customize it again see https://pkgdown.r-lib.org/articles/customise.html#navbar-heading for the current syntax :-)